### PR TITLE
Fixed som issues found in fakeApollo, and added missing types

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/node": "^16.6.1",
     "@types/react": "^17.0.17",
     "@types/react-dom": "^17.0.9",
+    "@types/react-router-dom": "^5.1.8",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0",

--- a/src/fakeApollo.tsx
+++ b/src/fakeApollo.tsx
@@ -9,24 +9,20 @@ type Data = {
   id: string;
 };
 
-const FakeAPIContext = createContext<
-  [Data[], Dispatch<SetStateAction<Data[]>>]
->([] as unknown as [Data[], Dispatch<SetStateAction<Data[]>>]);
+const FakeAPIContext = createContext<[Data[], Dispatch<SetStateAction<Data[]>>]>(
+  [] as unknown as [Data[], Dispatch<SetStateAction<Data[]>>]
+);
 
 export const FakeAPIProvider = (props: {
   children: JSX.Element | JSX.Element[];
   initialState: Data[];
 }) => {
   const state = useState<Data[]>(props.initialState);
-  return (
-    <FakeAPIContext.Provider value={state}>
-      {props.children}
-    </FakeAPIContext.Provider>
-  );
+  return <FakeAPIContext.Provider value={state}>{props.children}</FakeAPIContext.Provider>;
 };
 
 const useFakeLoading = () => {
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
   const load = useCallback(async () => {
     setLoading(true);
     await new Promise<void>((resolve) => setTimeout(() => resolve(), 1500));
@@ -52,7 +48,7 @@ export function useCreateDataMutation(): [
   const { load, loading } = useFakeLoading();
   return [
     async ({ data }) => {
-      load().then(() => {
+      return load().then(() => {
         setData((prev) => [...prev, { ...data, id: uuid() }]);
       });
     },
@@ -67,8 +63,8 @@ export function useRemoveDataMutation(): [
   const [, setData] = useContext(FakeAPIContext);
   const { load, loading } = useFakeLoading();
   return [
-    ({ id }) => {
-      load().then(() => {
+    async ({ id }) => {
+      return load().then(() => {
         setData((prev) => prev.filter((x) => x.id !== id));
       });
     },
@@ -83,11 +79,9 @@ export function useUpdateDataMutation(): [
   const [, setData] = useContext(FakeAPIContext);
   const { load, loading } = useFakeLoading();
   return [
-    ({ data, id }) => {
-      load().then(() => {
-        setData((prev) =>
-          prev.map((x) => (x.id === id ? { ...x, ...data } : data))
-        );
+    async ({ data, id }) => {
+      return load().then(() => {
+        setData((prev) => prev.map((x) => (x.id === id ? { ...x, ...data } : x)));
       });
     },
     { loading },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1741,6 +1741,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/history@*":
+  version "4.7.9"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.9.tgz#1cfb6d60ef3822c589f18e70f8b12f9a28ce8724"
+  integrity sha512-MUc6zSmU3tEVnkQ78q0peeEjKWPUADMlC/t++2bI8WnAG2tvYRPIgHG8lWkXwqc8MsUF6Z2MOf+Mh5sazOmhiQ==
+
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.1"
   resolved "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz"
@@ -1823,6 +1828,23 @@
   resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.9.tgz"
   integrity sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg==
   dependencies:
+    "@types/react" "*"
+
+"@types/react-router-dom@^5.1.8":
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.1.8.tgz#bf3e1c8149b3d62eaa206d58599de82df0241192"
+  integrity sha512-03xHyncBzG0PmDmf8pf3rehtjY0NpUj7TIN46FrT5n1ZWHPZvXz32gUyNboJ+xsL8cpg8bQVLcllptcQHvocrw==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*":
+  version "5.1.16"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.16.tgz#f3ba045fb96634e38b21531c482f9aeb37608a99"
+  integrity sha512-8d7nR/fNSqlTFGHti0R3F9WwIertOaaA1UEB8/jr5l5mDMOs4CidEgvvYMw4ivqrBK+vtVLxyTj2P+Pr/dtgzg==
+  dependencies:
+    "@types/history" "*"
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^17.0.17":


### PR DESCRIPTION
- Fixed useUpdateDataMutation to mutate only the correct element. 
- Changed all mutate functions to return promises
- Changed useFakeLoading to false as default, since it causes mutate functions to be loading before called.
- Added missing types for react-router-dom 